### PR TITLE
优化后端 Docker 构建与服务启动流程，提升使用体验

### DIFF
--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -1,42 +1,58 @@
-# 使用官方 Python 镜像作为基础镜像
-FROM python:3.10-slim
-
-# 安装必需的软件
-RUN apt-get update && apt-get install -y \
-    aria2 \
-    wget \
-    git \
-    tar \
-    nmap
-
-# 创建符号链接以满足脚本对/usr/bin/python3的期望
-RUN ln -s /usr/local/bin/python3 /usr/bin/python3
+# 使用官方 Go 1.23 镜像作为构建环境
+FROM golang:1.23 AS builder
+ENV GOPROXY="https://goproxy.cn|https://mirrors.tencentyun.com/go/|https://mirrors.aliyun.com/goproxy/|direct"
 
 # 设置工作目录
 WORKDIR /app
 
-# 将项目代码复制到容器中
-COPY . /app
+# 复制 go mod 和 sum 文件
+COPY go.mod go.sum ./
 
-# 安装项目依赖
-RUN pip install --no-cache-dir -i https://pypi.tuna.tsinghua.edu.cn/simple -r requirements.txt
+# 下载所有依赖
+RUN go mod download
 
-# 使用 aria2c 下载 ffuf
-RUN aria2c -x 10 -s 10 https://github.com/ffuf/ffuf/releases/download/v2.1.0/ffuf_2.1.0_linux_amd64.tar.gz \
-    && tar -xzf ffuf_2.1.0_linux_amd64.tar.gz \
-    && mv ffuf /usr/local/bin/
+# 复制源代码到容器中
+COPY . .
 
-# 克隆 OneForAll 仓库
-RUN git clone https://github.com/shmilylty/OneForAll.git /OneForAll
+# 构建应用程序，确保切换到包含 main.go 的目录，这里假设它在 cmd 目录下
+RUN CGO_ENABLED=0 GOOS=linux go build -o backend ./cmd/cyberedge.go
 
-# 修改 OneForAll 中的脚本文件权限
-RUN chmod +x /OneForAll/oneforall.py
+# 安装 nmap、subfinder、httpx 和 ffuf
+RUN apt-get update && apt-get install -y nmap \
+    && go install -v github.com/projectdiscovery/subfinder/v2/cmd/subfinder@latest \
+    && go install -v github.com/projectdiscovery/httpx/cmd/httpx@latest \
+    && go install -v github.com/ffuf/ffuf@latest
 
-# 暴露 Django 运行端口
-EXPOSE 1234
+# 获取 CA 证书（使用 Alpine 作为基础）
+FROM alpine:latest AS certs
+RUN apk --update add ca-certificates
 
-# 设置环境变量，确保 Python 输出配置在容器日志中
-ENV PYTHONUNBUFFERED 1
+# 使用 debian:bullseye-slim 作为最终基础镜像
+FROM debian:bullseye-slim
 
-# 运行数据库迁移和 Django 服务器
-CMD ["bash", "-c", "python manage.py makemigrations common target path_scanner subdomain_scanner port_scanner && python manage.py migrate && python manage.py runserver 0.0.0.0:1234"]
+# 安装 nmap
+RUN apt-get update && apt-get install -y nmap && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# 从 Alpine 中复制 CA 证书到最终镜像
+COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+
+# 从 builder 阶段复制可执行文件到根目录并重新命名为 backend
+COPY --from=builder /app/backend /app/backend
+
+# 从 builder 阶段复制 subfinder、httpx 和 ffuf 可执行文件
+COPY --from=builder /go/bin/subfinder /usr/local/bin/subfinder
+COPY --from=builder /go/bin/httpx /usr/local/bin/httpx
+COPY --from=builder /go/bin/ffuf /usr/local/bin/ffuf
+
+# 设置环境变量以确保应用使用正确的 CA 证书路径
+ENV SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
+ENV SSL_CERT_DIR=/etc/ssl/certs
+
+# 设置工作目录
+WORKDIR /app
+
+# 暴露应用运行端口
+EXPOSE 8081
+
+# 运行应用
+CMD ["/app/backend"]

--- a/cmd/cyberedge.go
+++ b/cmd/cyberedge.go
@@ -35,7 +35,7 @@ func main() {
 	defer cancel()
 
 	// 连接MongoDB数据库
-	client, err := setup.ConnectToMongoDB("mongodb://localhost:27017")
+	client, err := setup.ConnectToMongoDB("mongodb://mongodb:27017")
 	if err != nil {
 		logging.Error("连接MongoDB失败: %v", err)
 		return
@@ -47,7 +47,7 @@ func main() {
 	db := client.Database("cyberedgeDB")
 
 	// 初始化任务相关组件
-	taskService, asynqServer, err := setup.InitTaskComponents(db, "localhost:6379")
+	taskService, asynqServer, err := setup.InitTaskComponents(db, "redis:6379")
 	if err != nil {
 		logging.Error("初始化任务组件失败: %v", err)
 		return

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,70 +1,39 @@
 version: '3.8'
 
 services:
-  nginx-frontend:
-    build:
-      context: .
-      dockerfile: Dockerfile.frontend
-    ports:
-      - "4567:4567"
-    depends_on:
-      - django-backend
-    networks:
-      - app-network
-
-  django-backend:
+  backend:
     build:
       context: .
       dockerfile: Dockerfile.backend
     ports:
-      - "1234:1234"
+      - "8081:8081"
     depends_on:
+      - mongodb
       - redis
-      - db
-    networks:
-      - app-network
-    environment:
-      - DJANGO_RUNNING_IN_DOCKER=1
-      - DATABASE_URL=postgres://CyberEdge:Cyb3r3dg3@db:5432/CyberEdge
-      - CELERY_BROKER_URL=redis://redis:6379/0
-      - CELERY_RESULT_BACKEND=redis://redis:6379/0
 
-  celery-worker:
-    build:
-      context: .
-      dockerfile: Dockerfile.backend
-    command: celery -A cyberedge worker --loglevel=info
-    depends_on:
-      - django-backend
-      - redis
-    networks:
-      - app-network
-    environment:
-      - DJANGO_RUNNING_IN_DOCKER=1
-      - DATABASE_URL=postgres://CyberEdge:Cyb3r3dg3@db:5432/CyberEdge
-      - CELERY_BROKER_URL=redis://redis:6379/0
-      - CELERY_RESULT_BACKEND=redis://redis:6379/0
+  # frontend:
+  #   build:
+  #     context: .
+  #     dockerfile: Dockerfile.frontend
+  #   ports:
+  #     - "8080:8080"
+  #   depends_on:
+  #     - backend
+
+  mongodb:
+    image: mongo:latest
+    ports:
+      - "27017:27017"
+    volumes:
+      - mongo-data:/data/db
 
   redis:
-    image: "redis:alpine"
-    networks:
-      - app-network
+    image: redis:latest
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis-data:/data
 
-  db:
-    image: postgres:latest
-    environment:
-      - POSTGRES_USER=CyberEdge
-      - POSTGRES_PASSWORD=Cyb3r3dg3
-      - POSTGRES_DB=CyberEdge
-    networks:
-      - app-network
-    healthcheck:
-      test: [ "CMD-SHELL", "pg_isready -U $POSTGRES_USER -d $POSTGRES_DB" ]
-      interval: 10s
-      timeout: 5s
-      retries: 5
-      start_period: 10s
-
-networks:
-  app-network:
-    driver: bridge
+volumes:
+  mongo-data:
+  redis-data:

--- a/pkg/api/handlers/user_handler.go
+++ b/pkg/api/handlers/user_handler.go
@@ -5,8 +5,10 @@ package handlers
 import (
 	"cyberedge/pkg/models"
 	"cyberedge/pkg/service"
-	"github.com/gin-gonic/gin"
+	"fmt"
 	"net/http"
+
+	"github.com/gin-gonic/gin"
 )
 
 type UserHandler struct {
@@ -30,6 +32,7 @@ func (h *UserHandler) GenerateQRCode(c *gin.Context) {
 
 func (h *UserHandler) ValidateTOTP(c *gin.Context) {
 	var request models.TOTPValidationRequest
+	fmt.Println("request: ", request)
 	if err := c.ShouldBindJSON(&request); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "验证码和账户是必需的"})
 		return

--- a/pkg/api/router.go
+++ b/pkg/api/router.go
@@ -4,11 +4,12 @@ import (
 	"cyberedge/pkg/api/handlers"
 	"cyberedge/pkg/middleware"
 	"cyberedge/pkg/service"
+	"time"
+
 	"github.com/gin-contrib/cors"
 	"github.com/gin-contrib/sessions"
 	"github.com/gin-contrib/sessions/cookie"
 	"github.com/gin-gonic/gin"
-	"time"
 )
 
 type Router struct {


### PR DESCRIPTION
### **修改内容**
1. **优化 `Dockerfile.backend`**  
   - 调整为适配当前的 Golang 代码。
   
2. **改进 `docker-compose.yml`**  
   - 实现一键启动 Redis 和 MongoDB 服务。
   - 构建并运行后端服务镜像。

---

### **需要优化地方**
当前前端代码未包含在本仓库中，因此未直接构建前端镜像。后续优化方向建议如下：  
1. **推荐方案**：使用 Golang 直接内嵌前端静态资源，构建成单一后端服务镜像。  
2. **备用方案**：将前端独立镜像化，与后端服务分离运行。  

此外，当前没有公共镜像仓库，用户需要手动运行 `docker-compose up`。  
**建议**：
- 将构建的后端镜像打包并上传至公开镜像仓库（如 Coding、CNB 等），方便国内用户直接拉取使用。

---

### **当前后端镜像效果**
![image](https://github.com/user-attachments/assets/7b099a71-4ab8-4c12-9a5e-db198d5de784)
