### PR TITLE
fix install on macos and add git golang env in the container for other golang tools later

### DIFF
--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -4,43 +4,14 @@ WORKDIR /app
 
 # 安装必要的工具
 RUN apt-get update && \
-    apt-get install -y wget unzip nmap curl && \
+    apt-get install -y wget unzip nmap curl bash && \
     rm -rf /var/lib/apt/lists/*
 
 # 创建安装脚本
-RUN echo '#!/bin/bash \n\
-ARCH=$(uname -m) \n\
-if [ "$ARCH" = "aarch64" ] || [ "$ARCH" = "arm64" ]; then \n\
-    ARCH="arm64" \n\
-else \n\
-    ARCH="amd64" \n\
-fi \n\
-\n\
-# 下载和安装 CyberEdge \n\
-wget https://github.com/Symph0nia/CyberEdge/releases/download/v1.0.9/cyberedge-linux-${ARCH} -O cyberedge \n\
-chmod +x cyberedge \n\
-\n\
-# 安装 httpx \n\
-wget https://github.com/projectdiscovery/httpx/releases/download/v1.6.9/httpx_1.6.9_linux_${ARCH}.zip \n\
-unzip httpx_1.6.9_linux_${ARCH}.zip \n\
-mv httpx /usr/local/bin/ \n\
-rm httpx_1.6.9_linux_${ARCH}.zip \n\
-\n\
-# 安装 subfinder \n\
-wget https://github.com/projectdiscovery/subfinder/releases/download/v2.6.7/subfinder_2.6.7_linux_${ARCH}.zip \n\
-unzip subfinder_2.6.7_linux_${ARCH}.zip \n\
-mv subfinder /usr/local/bin/ \n\
-rm subfinder_2.6.7_linux_${ARCH}.zip \n\
-\n\
-# 安装 ffuf \n\
-wget https://github.com/ffuf/ffuf/releases/download/v2.1.0/ffuf_2.1.0_linux_${ARCH}.tar.gz \n\
-tar xvf ffuf_2.1.0_linux_${ARCH}.tar.gz \n\
-mv ffuf /usr/local/bin/ \n\
-rm ffuf_2.1.0_linux_${ARCH}.tar.gz \n\
-' > /app/install.sh && chmod +x /app/install.sh
+COPY install.sh /app/install.sh
 
 # 执行安装脚本
-RUN /app/install.sh
+RUN chmod +x /app/install.sh && bash /app/install.sh
 
 EXPOSE 31337
 

--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -4,7 +4,7 @@ WORKDIR /app
 
 # 安装必要的工具
 RUN apt-get update && \
-    apt-get install -y wget unzip nmap curl bash && \
+    apt-get install -y wget unzip nmap curl bash git golang && \
     rm -rf /var/lib/apt/lists/*
 
 # 创建安装脚本

--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -1,6 +1,6 @@
 FROM nginx:alpine
 
-RUN apk add --no-cache wget unzip
+RUN apk add --no-cache wget unzip bash
 
 # 添加 -o 参数来强制覆盖
 RUN wget https://github.com/Symph0nia/CyberEdge-Front/releases/download/v1.0.8/cyberedge-front.zip -O /tmp/frontend.zip && \

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# 获取系统架构
+ARCH=$(uname -m)
+
+# 判断系统架构并设置变量
+if [[ "$ARCH" == "aarch64" ]] || [[ "$ARCH" == "arm64" ]]; then
+    ARCH="arm64"
+else
+    ARCH="amd64"
+fi
+
+# 安装 CyberEdge
+echo "Installing CyberEdge..."
+wget -q https://github.com/Symph0nia/CyberEdge/releases/download/v1.0.9/cyberedge-linux-${ARCH} -O cyberedge
+chmod +x cyberedge
+
+# 安装 httpx
+echo "Installing httpx..."
+wget -q https://github.com/projectdiscovery/httpx/releases/download/v1.6.9/httpx_1.6.9_linux_${ARCH}.zip -O /tmp/httpx.zip
+unzip -q /tmp/httpx.zip -d /tmp
+mv /tmp/httpx /usr/local/bin/
+rm /tmp/httpx.zip
+
+# 安装 subfinder
+echo "Installing subfinder..."
+wget -q https://github.com/projectdiscovery/subfinder/releases/download/v2.6.7/subfinder_2.6.7_linux_${ARCH}.zip -O /tmp/subfinder.zip
+unzip -q /tmp/subfinder.zip -d /tmp
+mv /tmp/subfinder /usr/local/bin/
+rm /tmp/subfinder.zip
+
+# 安装 ffuf
+echo "Installing ffuf..."
+wget -q https://github.com/ffuf/ffuf/releases/download/v2.1.0/ffuf_2.1.0_linux_${ARCH}.tar.gz -O /tmp/ffuf.tar.gz
+tar -xf /tmp/ffuf.tar.gz -C /tmp
+mv /tmp/ffuf /usr/local/bin/
+rm /tmp/ffuf.tar.gz
+
+echo "Installation complete."

--- a/install.sh
+++ b/install.sh
@@ -36,4 +36,13 @@ tar -xf /tmp/ffuf.tar.gz -C /tmp
 mv /tmp/ffuf /usr/local/bin/
 rm /tmp/ffuf.tar.gz
 
+# 安装 fscan
+echo "Installing fscan..."
+git clone --depth=1 https://github.com/shadow1ng/fscan.git
+cd fscan
+go mod tidy
+go build -o fscan
+mv fscan /usr/local/bin/
+cd ..
+
 echo "Installation complete."


### PR DESCRIPTION
there are some errors when installing on mac

```
 => ERROR [backend 4/5] RUN echo '#!/bin/bash \nARCH=$(uname -m) \nif [ "$ARCH" = "aarch64" ] || [ "$ARCH" = "arm64" ]; then \n    ARCH="arm64" \nelse \n    ARCH="amd64" \nfi \n\nwge  0.2s
------
 > [backend 4/5] RUN echo '#!/bin/bash \nARCH=$(uname -m) \nif [ "$ARCH" = "aarch64" ] || [ "$ARCH" = "arm64" ]; then \n    ARCH="arm64" \nelse \n    ARCH="amd64" \nfi \n\nwget https://github.com/Symph0nia/CyberEdge/releases/download/v1.0.9/cyberedge-linux-${ARCH} -O cyberedge \nchmod +x cyberedge \n\nwget https://github.com/projectdiscovery/httpx/releases/download/v1.6.9/httpx_1.6.9_linux_${ARCH}.zip \nunzip httpx_1.6.9_linux_${ARCH}.zip \nmv httpx /usr/local/bin/ \nrm httpx_1.6.9_linux_${ARCH}.zip \n\nwget https://github.com/projectdiscovery/subfinder/releases/download/v2.6.7/subfinder_2.6.7_linux_${ARCH}.zip \nunzip subfinder_2.6.7_linux_${ARCH}.zip \nmv subfinder /usr/local/bin/ \nrm subfinder_2.6.7_linux_${ARCH}.zip \n\nwget https://github.com/ffuf/ffuf/releases/download/v2.1.0/ffuf_2.1.0_linux_${ARCH}.tar.gz \ntar xvf ffuf_2.1.0_linux_${ARCH}.tar.gz \nmv ffuf /usr/local/bin/ \nrm ffuf_2.1.0_linux_${ARCH}.tar.gz \n' > /app/install.sh && chmod +x /app/install.sh:
0.111 runc run failed: unable to start container process: error during container init: exec: "/bin/sh": stat /bin/sh: no such file or directory
------
failed to solve: process "/bin/sh -c echo '#!/bin/bash \\nARCH=$(uname -m) \\nif [ \"$ARCH\" = \"aarch64\" ] || [ \"$ARCH\" = \"arm64\" ]; then \\n    ARCH=\"arm64\" \\nelse \\n    ARCH=\"amd64\" \\nfi \\n\\nwget https://github.com/Symph0nia/CyberEdge/releases/download/v1.0.9/cyberedge-linux-${ARCH} -O cyberedge \\nchmod +x cyberedge \\n\\nwget https://github.com/projectdiscovery/httpx/releases/download/v1.6.9/httpx_1.6.9_linux_${ARCH}.zip \\nunzip httpx_1.6.9_linux_${ARCH}.zip \\nmv httpx /usr/local/bin/ \\nrm httpx_1.6.9_linux_${ARCH}.zip \\n\\nwget https://github.com/projectdiscovery/subfinder/releases/download/v2.6.7/subfinder_2.6.7_linux_${ARCH}.zip \\nunzip subfinder_2.6.7_linux_${ARCH}.zip \\nmv subfinder /usr/local/bin/ \\nrm subfinder_2.6.7_linux_${ARCH}.zip \\n\\nwget https://github.com/ffuf/ffuf/releases/download/v2.1.0/ffuf_2.1.0_linux_${ARCH}.tar.gz \\ntar xvf ffuf_2.1.0_linux_${ARCH}.tar.gz \\nmv ffuf /usr/local/bin/ \\nrm ffuf_2.1.0_linux_${ARCH}.tar.gz \\n' > /app/install.sh && chmod +x /app/install.sh" did not complete successfully: exit code: 1
```

```
=> ERROR [backend 5/6] RUN chmod +x /app/install.sh                                                                                                                                    0.2s
------
 > [backend 5/6] RUN chmod +x /app/install.sh:
0.151 runc run failed: unable to start container process: error during container init: exec: "/bin/sh": stat /bin/sh: no such file or directory
------
failed to solve: process "/bin/sh -c chmod +x /app/install.sh" did not complete successfully: exit code: 1
```